### PR TITLE
Switch to gitlab ci

### DIFF
--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -29,13 +29,13 @@ gcc_image:
     extends: .image
     variables:
       BASE: dune-gdt-testing_base_gcc:master
-      IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
+      IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
 
 clang_image:
     extends: .image
     variables:
       BASE: dune-gdt-testing_base_clang:master
-      IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA}
+      IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
 
 # ************ TEST EXECUTION ************
 .cpp:
@@ -48,11 +48,11 @@ clang_image:
 
 gcc:
     extends: .cpp
-    image: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
+    image: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
 
 clang:
     extends: .cpp
-    image: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA}
+    image: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
 
 # ************ CLEANUP ************
 .cleanup:
@@ -60,8 +60,8 @@ clang:
     stage: cleanup
     variables:
       APIBASE: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories/"
-      GCC_IMAGE_HUB: dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
-      CLANG_IMAGE_HUB: dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHA}
+      GCC_IMAGE_HUB: dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
+      CLANG_IMAGE_HUB: dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
     before_script:
       - echo $DOCKER_PW | docker login --username="$DOCKER_USER" --password-stdin
 
@@ -74,15 +74,15 @@ success:
 gcc_failure:
     extends: .cleanup
     script:
-      - docker pull ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
-      - docker tag ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA} ${GCC_IMAGE_HUB}
+      - docker pull ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
+      - docker tag ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA} ${GCC_IMAGE_HUB}
       - docker push ${GCC_IMAGE_HUB}
     when: on_failure
 
 clang_failure:
     extends: .cleanup
     script:
-      - docker pull ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA}
-      - docker tag ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA} ${CLANG_IMAGE_HUB}
+      - docker pull ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
+      - docker tag ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA} ${CLANG_IMAGE_HUB}
       - docker push ${CLANG_IMAGE_HUB}
     when: on_failure

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -1,0 +1,94 @@
+
+stages:
+  - prepare
+  - test
+  - cleanup
+
+variables:
+    GCC_IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
+    GCC_IMAGE_HUB: dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
+    CLANG_IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA}
+    CLANG_IMAGE_HUB: dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHA}
+
+.docker-in-docker:
+    image: docker:stable
+    variables:
+        DOCKER_HOST: tcp://docker:2375/
+        DOCKER_DRIVER: overlay2
+    before_script:
+        - apk --update add openssh-client rsync git file bash python3 curl
+        - pip3 install jinja2
+        - 'export SHARED_PATH="${CI_PROJECT_DIR}/shared"'
+        - mkdir -p ${SHARED_PATH}
+        - docker login -u "gitlab-ci-token" -p "$CI_BUILD_TOKEN" "$CI_REGISTRY"
+    services:
+        - docker:dind
+
+# ************ IMAGE BUILDING ************
+.image:
+    extends: .docker-in-docker
+    stage: prepare
+    script:
+      - docker build --build-arg BASE=${BASE} -t ${IMAGE} -f .ci/docker/Dockerfile .
+      - docker push ${IMAGE}
+
+gcc_image:
+    extends: .image
+    variables:
+      BASE: dune-gdt-testing_base_gcc:master
+      IMAGE: ${GCC_IMAGE}
+
+clang_image:
+    extends: .image
+    variables:
+        BASE: dune-gdt-testing_base_clang:master
+        IMAGE: ${CLANG_IMAGE}
+
+# ************ TEST EXECUTION ************
+.cpp:
+    stage: test
+    before_script:
+      - docker login -u "gitlab-ci-token" -p "$CI_BUILD_TOKEN" "$CI_REGISTRY"
+    script: /home/dune-ci/src/dune-gdt/.ci/drone/script.bash
+    variables:
+      MY_MODULE: dune-gdt
+
+gcc:
+    extends: .cpp
+    image: dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
+
+clang:
+    extends: .cpp
+    image: dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHA}
+
+# ************ CLEANUP ************
+.cleanup:
+    extends: .docker-in-docker
+    stage: cleanup
+    variables:
+        REPO_ID: 1
+        API: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories/${REPO_ID}"
+    before_script:
+      - echo $DOCKER_PW | docker login --username="$DOCKER_USER" --password-stdin
+
+success:
+    extends: .cleanup
+    script: |
+      echo curl --request DELETE --header "PRIVATE-TOKEN: <your_access_token>" ${API}
+    when: on_success
+
+gcc_failure:
+    extends: .cleanup
+    script:
+      - docker pull ${GCC_IMAGE}
+      - docker tag ${GCC_IMAGE} ${GCC_IMAGE_HUB}
+      - docker push ${GCC_IMAGE_HUB}
+    when: on_failure
+
+clang_failure:
+    extends: .cleanup
+    script:
+      - docker pull ${CLANG_IMAGE}
+      - docker tag ${CLANG_IMAGE} ${CLANG_IMAGE_HUB}
+      - docker push ${CLANG_IMAGE_HUB}
+    when: on_failure

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -41,8 +41,6 @@ clang_image:
 # ************ TEST EXECUTION ************
 .cpp:
     stage: test
-    before_script:
-      - echo "$CI_BUILD_TOKEN" | docker login -u "gitlab-ci-token" --password-stdin  "$CI_REGISTRY"
     script: /home/dune-ci/src/dune-gdt/.ci/drone/script.bash
     variables:
       MY_MODULE: dune-gdt

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -13,7 +13,8 @@ stages:
         - pip3 install jinja2
         - 'export SHARED_PATH="${CI_PROJECT_DIR}/shared"'
         - mkdir -p ${SHARED_PATH}
-        - echo "$CI_BUILD_TOKEN" | docker login -u "gitlab-ci-token" --password-stdin  "$CI_REGISTRY"
+        #- echo "$CI_BUILD_TOKEN" | docker login -u "gitlab-ci-token" --password-stdin  "$CI_REGISTRY"
+        - echo $DOCKER_PW | docker login --username="$DOCKER_USER" --password-stdin
     services:
         - docker:dind
 
@@ -29,13 +30,13 @@ gcc_image:
     extends: .image
     variables:
       BASE: dune-gdt-testing_base_gcc:master
-      IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
+      IMAGE: dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
 
 clang_image:
     extends: .image
     variables:
       BASE: dune-gdt-testing_base_clang:master
-      IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
+      IMAGE: dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
 
 # ************ TEST EXECUTION ************
 .cpp:
@@ -48,11 +49,11 @@ clang_image:
 
 gcc:
     extends: .cpp
-    image: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
+    image: dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
 
 clang:
     extends: .cpp
-    image: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
+    image: dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
 
 # ************ CLEANUP ************
 .cleanup:
@@ -74,15 +75,15 @@ success:
 gcc_failure:
     extends: .cleanup
     script:
-      - docker pull ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
-      - docker tag ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA} ${GCC_IMAGE_HUB}
+      - docker pull dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA}
+      #- docker tag dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHORT_SHA} ${GCC_IMAGE_HUB}
       - docker push ${GCC_IMAGE_HUB}
     when: on_failure
 
 clang_failure:
     extends: .cleanup
     script:
-      - docker pull ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
-      - docker tag ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA} ${CLANG_IMAGE_HUB}
+      - docker pull dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA}
+      #- docker tag dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHORT_SHA} ${CLANG_IMAGE_HUB}
       - docker push ${CLANG_IMAGE_HUB}
     when: on_failure

--- a/.ci/gitlab/ci.yml
+++ b/.ci/gitlab/ci.yml
@@ -1,14 +1,7 @@
-
 stages:
   - prepare
   - test
   - cleanup
-
-variables:
-    GCC_IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
-    GCC_IMAGE_HUB: dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
-    CLANG_IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA}
-    CLANG_IMAGE_HUB: dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHA}
 
 .docker-in-docker:
     image: docker:stable
@@ -20,7 +13,7 @@ variables:
         - pip3 install jinja2
         - 'export SHARED_PATH="${CI_PROJECT_DIR}/shared"'
         - mkdir -p ${SHARED_PATH}
-        - docker login -u "gitlab-ci-token" -p "$CI_BUILD_TOKEN" "$CI_REGISTRY"
+        - echo "$CI_BUILD_TOKEN" | docker login -u "gitlab-ci-token" --password-stdin  "$CI_REGISTRY"
     services:
         - docker:dind
 
@@ -36,38 +29,39 @@ gcc_image:
     extends: .image
     variables:
       BASE: dune-gdt-testing_base_gcc:master
-      IMAGE: ${GCC_IMAGE}
+      IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
 
 clang_image:
     extends: .image
     variables:
-        BASE: dune-gdt-testing_base_clang:master
-        IMAGE: ${CLANG_IMAGE}
+      BASE: dune-gdt-testing_base_clang:master
+      IMAGE: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA}
 
 # ************ TEST EXECUTION ************
 .cpp:
     stage: test
     before_script:
-      - docker login -u "gitlab-ci-token" -p "$CI_BUILD_TOKEN" "$CI_REGISTRY"
+      - echo "$CI_BUILD_TOKEN" | docker login -u "gitlab-ci-token" --password-stdin  "$CI_REGISTRY"
     script: /home/dune-ci/src/dune-gdt/.ci/drone/script.bash
     variables:
       MY_MODULE: dune-gdt
 
 gcc:
     extends: .cpp
-    image: dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
+    image: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
 
 clang:
     extends: .cpp
-    image: dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHA}
+    image: ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA}
 
 # ************ CLEANUP ************
 .cleanup:
     extends: .docker-in-docker
     stage: cleanup
     variables:
-        REPO_ID: 1
-        API: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories/${REPO_ID}"
+      APIBASE: "${CI_API_V4_URL}/projects/${CI_PROJECT_ID}/registry/repositories/"
+      GCC_IMAGE_HUB: dunecommunity/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
+      CLANG_IMAGE_HUB: dunecommunity/dune-gdt-testing_clang:${CI_COMMIT_SHA}
     before_script:
       - echo $DOCKER_PW | docker login --username="$DOCKER_USER" --password-stdin
 
@@ -80,15 +74,15 @@ success:
 gcc_failure:
     extends: .cleanup
     script:
-      - docker pull ${GCC_IMAGE}
-      - docker tag ${GCC_IMAGE} ${GCC_IMAGE_HUB}
+      - docker pull ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA}
+      - docker tag ${CI_REGISTRY_IMAGE}/dune-gdt-testing_gcc:${CI_COMMIT_SHA} ${GCC_IMAGE_HUB}
       - docker push ${GCC_IMAGE_HUB}
     when: on_failure
 
 clang_failure:
     extends: .cleanup
     script:
-      - docker pull ${CLANG_IMAGE}
-      - docker tag ${CLANG_IMAGE} ${CLANG_IMAGE_HUB}
+      - docker pull ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA}
+      - docker tag ${CI_REGISTRY_IMAGE}/dune-gdt-testing_clang:${CI_COMMIT_SHA} ${CLANG_IMAGE_HUB}
       - docker push ${CLANG_IMAGE_HUB}
     when: on_failure

--- a/.gitsuper
+++ b/.gitsuper
@@ -1,118 +1,124 @@
 [supermodule]
 remote = git@github.com:dune-community/dune-gdt-super.git
-status = 1a3bcab04b011a5d6e44f9983cae6ff89fa695e8 bin (heads/master)
-	 28c9ce81c14c878a71e907ab05b9bb72df77883e config.opts (heads/master)
-	 f308c6637edd65dcb83c4c1a46feaf05b958130e dune-alugrid (v2.6.0-7-gf308c663)
-	 76d7f0c9886a061571cb8dc66dd45a4ef86e7a58 dune-common (v2.2.1-2269-g76d7f0c9)
-	+36634986b34d08cd8f3805e2e607a7bba86ff25d dune-gdt (heads/saddlepoint)
-	 5235397bc16d24c759a1672fed7b8cfde4852e52 dune-geometry (v2.2.0-834-g5235397)
-	 af5766f0df47e3d0b62ea486efb9cdbf8e1cfc52 dune-grid (v2.2.0-2671-gaf5766f0d)
-	 1369ae9329d0928480d6b18ed772fc77e1abf752 dune-grid-glue (v2.4.0-161-g1369ae9)
-	 ef68ae0ec40f9d369e4ea9b31e560af6af545bf6 dune-istl (v2.6.0-4-gef68ae0e)
-	 5a1f77d7a0a41c2d065b29f00dda0871ec70337b dune-localfunctions (v2.6.0-2-g5a1f77d)
-	 6d2a4680493a2483d53f9dd05a19dd6b5f436572 dune-pybindxi (v2.2.1-30-g6d2a468)
-	 58bd932e2311a288e0163d041f836b50f19111cb dune-testtools (remotes/origin/testname_listing_hack2.6)
-	 07f9700459c616186737a9a34277f2edee76f475 dune-uggrid (v2.6.0-1-g07f97004)
-	 27a8010443c03eebddc3a910bdbef63ccf1f3e5d dune-xt-common (heads/master)
-	 376e88d14fd23ea12c3e23befc3fc967d4833751 dune-xt-data (heads/master)
-	 2da2612032ce64337f5af5cfec68d3c6d639e178 dune-xt-functions (heads/master)
-	 654c823f698418b67a696618342b54324f2cc151 dune-xt-grid (heads/master)
-	 d1ffc46178cb9d93308294c5144afb4d7d0f0d82 dune-xt-la (heads/master)
-	 09d0378f616b94d68bcdd9fc6114813181849ec0 scripts (heads/master)
-commit = ee1fda4fe42ee5f7c744cf529f84adf689251563
+status = 1a3bcab04b011a5d6e44f9983cae6ff89fa695e8 bin (remotes/origin/HEAD)
+	 20a673b9dad7e2e25bd97defa8849debb59d247c config.opts (heads/master)
+	 8f2c5aba441417bf2c42f22272f538c68a89cc4a dune-alugrid (remotes/origin/releases/2.5)
+	 707acf201d5a754c80f87cc4d71aa36bf29a6e3f dune-common (v2.5.1-9-g707acf20)
+	+43de37f70b1ebcb2d363adfe4f99f8e7b010d86a dune-gdt (heads/switch_to_gitlab-ci)
+	 390a2c503783bbed778a8ff610f8c5ca09c238d0 dune-geometry (v2.5.1-5-g390a2c5)
+	 d7b20bbc5f6fdcfc312beb0ea5d16d39ea26904e dune-grid (v2.5.1-2-gd7b20bbc5)
+	 9e29a333e8af02382d80b95335a784d5ce1ea2c8 dune-grid-glue (v2.4.0-70-g9e29a33)
+	 63df56a54f81eda308233a683eb329e77e69f0a9 dune-istl (v2.5.1rc1)
+	 0d757d65e5d57134a7ecf304e35d063f4ccc7116 dune-localfunctions (v2.5.1rc1)
+	 8a69fc68165780921bbba77da338b6932daf983c dune-pybindxi (v2.2.1-16-g8a69fc6)
+	 741e4f8e53bdd3e1b6e19d84eb22b6e3dc48526c dune-python (remotes/origin/releases/2.5)
+	 26cc8cb4161a3a51002ab2a81b8c81d2c951ee79 dune-testtools (heads/p/renemilk/testname_listing_hack_no-skiptest)
+	 0a74e7dd0b2115778a5d490dab08a2ed07fcaa1e dune-uggrid (v2.5.2)
+	 b8bd7ace2ae1ea9b3ff8409fe3013d755c5bf6e9 dune-xt-common (remotes/origin/releases/18.10)
+	 e69fd76a2344e7ed99858ff9cb0988437c439b5a dune-xt-data (remotes/origin/releases/18.10)
+	 841cdccca42c349ff92991639a2466837617d29c dune-xt-functions (remotes/origin/releases/18.10)
+	 0622536cb9781d206af744f456b9f716c26f4505 dune-xt-grid (remotes/origin/releases/18.10)
+	 3af9db50129a87a2e2426540ab7c5c7432209ef3 dune-xt-la (remotes/origin/releases/18.10)
+	 09d0378f616b94d68bcdd9fc6114813181849ec0 scripts (remotes/origin/HEAD)
+commit = 5f5841ee7a2dff290b98845c46262151752189c1
 
 [submodule.bin]
-remote = git@github.com:dune-community/local-bin.git
+remote = https://github.com/dune-community/local-bin.git
 status = 
 commit = 1a3bcab04b011a5d6e44f9983cae6ff89fa695e8
 
 [submodule.config.opts]
-remote = git@github.com:dune-community/config.opts.git
+remote = https://github.com/dune-community/config.opts.git
 status = 
-commit = 28c9ce81c14c878a71e907ab05b9bb72df77883e
+commit = 20a673b9dad7e2e25bd97defa8849debb59d247c
 
 [submodule.dune-alugrid]
 remote = https://github.com/dune-mirrors/dune-alugrid.git
 status = 
-commit = f308c6637edd65dcb83c4c1a46feaf05b958130e
+commit = 8f2c5aba441417bf2c42f22272f538c68a89cc4a
 
 [submodule.dune-common]
-remote = git@github.com:dune-community/dune-common.git
+remote = https://github.com/dune-community/dune-common.git
 status = 
-commit = 76d7f0c9886a061571cb8dc66dd45a4ef86e7a58
+commit = 707acf201d5a754c80f87cc4d71aa36bf29a6e3f
 
 [submodule.dune-gdt]
-remote = git@github.com:dune-community/dune-gdt.git
-status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (heads/master)
-commit = 36634986b34d08cd8f3805e2e607a7bba86ff25d
+remote = https://github.com/dune-community/dune-gdt.git
+status = 0fe2d7bb19a198ee8d099ff308b9208af0914eb4 .vcsetup (remotes/origin/HEAD)
+commit = 43de37f70b1ebcb2d363adfe4f99f8e7b010d86a
 
 [submodule.dune-geometry]
-remote = git@github.com:dune-community/dune-geometry.git
+remote = https://github.com/dune-community/dune-geometry.git
 status = 
-commit = 5235397bc16d24c759a1672fed7b8cfde4852e52
+commit = 390a2c503783bbed778a8ff610f8c5ca09c238d0
 
 [submodule.dune-grid]
-remote = git@github.com:dune-community/dune-grid.git
+remote = https://github.com/dune-community/dune-grid.git
 status = 
-commit = af5766f0df47e3d0b62ea486efb9cdbf8e1cfc52
+commit = d7b20bbc5f6fdcfc312beb0ea5d16d39ea26904e
 
 [submodule.dune-grid-glue]
 remote = https://github.com/dune-mirrors/dune-grid-glue.git
 status = 
-commit = 1369ae9329d0928480d6b18ed772fc77e1abf752
+commit = 9e29a333e8af02382d80b95335a784d5ce1ea2c8
 
 [submodule.dune-istl]
 remote = https://github.com/dune-mirrors/dune-istl.git
 status = 
-commit = ef68ae0ec40f9d369e4ea9b31e560af6af545bf6
+commit = 63df56a54f81eda308233a683eb329e77e69f0a9
 
 [submodule.dune-localfunctions]
 remote = https://github.com/dune-mirrors/dune-localfunctions.git
 status = 
-commit = 5a1f77d7a0a41c2d065b29f00dda0871ec70337b
+commit = 0d757d65e5d57134a7ecf304e35d063f4ccc7116
 
 [submodule.dune-pybindxi]
-remote = git@github.com:dune-community/dune-pybindxi.git
-status = c0b1735fab0ecbd4bb4f1eaa27cb65fe813e98f0 .vcsetup (heads/master)
-commit = 6d2a4680493a2483d53f9dd05a19dd6b5f436572
+remote = https://github.com/dune-community/dune-pybindxi.git
+status = a18500d497d2ffa2f627bc6e7da0aa1169b81ea3 .vcsetup (a18500d)
+commit = 8a69fc68165780921bbba77da338b6932daf983c
+
+[submodule.dune-python]
+remote = https://github.com/dune-mirrors/dune-python.git
+status = 
+commit = 741e4f8e53bdd3e1b6e19d84eb22b6e3dc48526c
 
 [submodule.dune-testtools]
-remote = git@github.com:dune-community/dune-testtools.git
+remote = https://github.com/dune-mirrors/dune-testtools.git
 status = 
-commit = 58bd932e2311a288e0163d041f836b50f19111cb
+commit = 26cc8cb4161a3a51002ab2a81b8c81d2c951ee79
 
 [submodule.dune-uggrid]
 remote = https://github.com/dune-mirrors/dune-uggrid.git
 status = 
-commit = 07f9700459c616186737a9a34277f2edee76f475
+commit = 0a74e7dd0b2115778a5d490dab08a2ed07fcaa1e
 
 [submodule.dune-xt-common]
-remote = git@github.com:dune-community/dune-xt-common.git
-status = cc1bbdac283f4b9323c64345030f1b8f634b88d5 .vcsetup (heads/master)
-commit = 27a8010443c03eebddc3a910bdbef63ccf1f3e5d
+remote = https://github.com/dune-community/dune-xt-common.git
+status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (heads/master)
+commit = b8bd7ace2ae1ea9b3ff8409fe3013d755c5bf6e9
 
 [submodule.dune-xt-data]
-remote = git@github.com:dune-community/dune-xt-data
-status = cc1bbdac283f4b9323c64345030f1b8f634b88d5 .vcsetup (heads/master)
-commit = 376e88d14fd23ea12c3e23befc3fc967d4833751
+remote = https://github.com/dune-community/dune-xt-data
+status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (heads/master)
+commit = e69fd76a2344e7ed99858ff9cb0988437c439b5a
 
 [submodule.dune-xt-functions]
-remote = git@github.com:dune-community/dune-xt-functions.git
-status = cc1bbdac283f4b9323c64345030f1b8f634b88d5 .vcsetup (heads/master)
-commit = 2da2612032ce64337f5af5cfec68d3c6d639e178
+remote = https://github.com/dune-community/dune-xt-functions.git
+status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (heads/master)
+commit = 841cdccca42c349ff92991639a2466837617d29c
 
 [submodule.dune-xt-grid]
-remote = git@github.com:dune-community/dune-xt-grid.git
-status = cc1bbdac283f4b9323c64345030f1b8f634b88d5 .vcsetup (heads/master)
-commit = 654c823f698418b67a696618342b54324f2cc151
+remote = https://github.com/dune-community/dune-xt-grid.git
+status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (heads/master-10-g2424627)
+commit = 0622536cb9781d206af744f456b9f716c26f4505
 
 [submodule.dune-xt-la]
-remote = git@github.com:dune-community/dune-xt-la.git
-status = cc1bbdac283f4b9323c64345030f1b8f634b88d5 .vcsetup (heads/master)
-commit = d1ffc46178cb9d93308294c5144afb4d7d0f0d82
+remote = https://github.com/dune-community/dune-xt-la.git
+status = 2424627f0ad5de7e4aaa5e7f48bc2a02414d95a1 .vcsetup (heads/master-11-g2424627)
+commit = 3af9db50129a87a2e2426540ab7c5c7432209ef3
 
 [submodule.scripts]
 remote = https://github.com/wwu-numerik/scripts.git
-status = fb5ebc10e647d637c69497af2ec2560847eb2112 python/pylicense (v0.2.0~10)
+status = fb5ebc10e647d637c69497af2ec2560847eb2112 python/pylicense (fb5ebc1)
 commit = 09d0378f616b94d68bcdd9fc6114813181849ec0
 

--- a/.gitsuper
+++ b/.gitsuper
@@ -4,7 +4,7 @@ status = 1a3bcab04b011a5d6e44f9983cae6ff89fa695e8 bin (remotes/origin/HEAD)
 	 20a673b9dad7e2e25bd97defa8849debb59d247c config.opts (heads/master)
 	 8f2c5aba441417bf2c42f22272f538c68a89cc4a dune-alugrid (remotes/origin/releases/2.5)
 	 707acf201d5a754c80f87cc4d71aa36bf29a6e3f dune-common (v2.5.1-9-g707acf20)
-	+43de37f70b1ebcb2d363adfe4f99f8e7b010d86a dune-gdt (heads/switch_to_gitlab-ci)
+	+d595975b64b8575a7087493f5ed5550499b948c1 dune-gdt (heads/switch_to_gitlab-ci)
 	 390a2c503783bbed778a8ff610f8c5ca09c238d0 dune-geometry (v2.5.1-5-g390a2c5)
 	 d7b20bbc5f6fdcfc312beb0ea5d16d39ea26904e dune-grid (v2.5.1-2-gd7b20bbc5)
 	 9e29a333e8af02382d80b95335a784d5ce1ea2c8 dune-grid-glue (v2.4.0-70-g9e29a33)
@@ -45,7 +45,7 @@ commit = 707acf201d5a754c80f87cc4d71aa36bf29a6e3f
 [submodule.dune-gdt]
 remote = https://github.com/dune-community/dune-gdt.git
 status = 0fe2d7bb19a198ee8d099ff308b9208af0914eb4 .vcsetup (remotes/origin/HEAD)
-commit = 43de37f70b1ebcb2d363adfe4f99f8e7b010d86a
+commit = d595975b64b8575a7087493f5ed5550499b948c1
 
 [submodule.dune-geometry]
 remote = https://github.com/dune-community/dune-geometry.git


### PR DESCRIPTION
In the current state pipelines for push builds should already run successfully. 

For PR builds to work I will deploy a GitHub app (just like in pyMOR) that pushes branches with merge commits directly into the gitlab repo. 

Once that's done I will remove the drone setup and switch the branch protection settings accordingly.