### PR TITLE
Clang format 8

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,1 @@
-.vcsetup/.clang-format-6
+.vcsetup/.clang-format-8

--- a/dune/gdt/local/assembler/operator-applicators.hh
+++ b/dune/gdt/local/assembler/operator-applicators.hh
@@ -208,7 +208,7 @@ public:
 
   LocalIntersectionOperatorApplicator(const ThisType& other)
     : LocalIntersectionOperatorApplicator(
-          *other.local_operator_, other.range_inside_, other.range_outside_, other.param_)
+        *other.local_operator_, other.range_inside_, other.range_outside_, other.param_)
   {}
 
   BaseType* copy() override final

--- a/dune/gdt/local/finite-elements/flattop.hh
+++ b/dune/gdt/local/finite-elements/flattop.hh
@@ -162,11 +162,11 @@ class LocalFlatTop2dCubeFiniteElement : public LocalFiniteElementDefault<D, 2, R
 public:
   LocalFlatTop2dCubeFiniteElement(const double& overlap = 0.5)
     : BaseType(
-          1,
-          LocalFlatTop2dCubeFiniteElementBasis<D, R>(overlap).copy(),
-          LocalLagrangeFiniteElementFactory<D, 2, R, 1>::create(Dune::GeometryTypes::cube(2), 1)->coefficients().copy(),
-          LocalL2FiniteElementInterpolation<D, 2, R, 1>(LocalFlatTop2dCubeFiniteElementBasis<D, R>(overlap)).copy(),
-          {})
+        1,
+        LocalFlatTop2dCubeFiniteElementBasis<D, R>(overlap).copy(),
+        LocalLagrangeFiniteElementFactory<D, 2, R, 1>::create(Dune::GeometryTypes::cube(2), 1)->coefficients().copy(),
+        LocalL2FiniteElementInterpolation<D, 2, R, 1>(LocalFlatTop2dCubeFiniteElementBasis<D, R>(overlap)).copy(),
+        {})
   {}
 }; // class LocalFlatTop2dCubeFiniteElement
 

--- a/dune/gdt/local/functionals/integrals.hh
+++ b/dune/gdt/local/functionals/integrals.hh
@@ -42,12 +42,12 @@ public:
     , over_integrate_(over_integrate)
   {}
 
-  LocalElementIntegralFunctional(typename GenericIntegrand::GenericOrderFunctionType order_function,
-                                 typename GenericIntegrand::GenericEvaluateFunctionType evaluate_function,
-                                 typename GenericIntegrand::GenericPostBindFunctionType post_bind_function =
-                                     [](const E&) {},
-                                 const XT::Common::ParameterType& param_type = {},
-                                 const int over_integrate = 0)
+  LocalElementIntegralFunctional(
+      typename GenericIntegrand::GenericOrderFunctionType order_function,
+      typename GenericIntegrand::GenericEvaluateFunctionType evaluate_function,
+      typename GenericIntegrand::GenericPostBindFunctionType post_bind_function = [](const E&) {},
+      const XT::Common::ParameterType& param_type = {},
+      const int over_integrate = 0)
     : BaseType(param_type)
     , integrand_(GenericIntegrand(order_function, evaluate_function, post_bind_function).copy())
     , over_integrate_(over_integrate)
@@ -123,12 +123,12 @@ public:
     , over_integrate_(over_integrate)
   {}
 
-  LocalIntersectionIntegralFunctional(typename GenericIntegrand::GenericOrderFunctionType order_function,
-                                      typename GenericIntegrand::GenericEvaluateFunctionType evaluate_function,
-                                      typename GenericIntegrand::GenericPostBindFunctionType post_bind_function =
-                                          [](const I&) {},
-                                      const XT::Common::ParameterType& param_type = {},
-                                      const int over_integrate = 0)
+  LocalIntersectionIntegralFunctional(
+      typename GenericIntegrand::GenericOrderFunctionType order_function,
+      typename GenericIntegrand::GenericEvaluateFunctionType evaluate_function,
+      typename GenericIntegrand::GenericPostBindFunctionType post_bind_function = [](const I&) {},
+      const XT::Common::ParameterType& param_type = {},
+      const int over_integrate = 0)
     : BaseType(param_type)
     , integrand_(GenericIntegrand(order_function, evaluate_function, post_bind_function).copy())
     , over_integrate_(over_integrate)

--- a/dune/gdt/local/integrands/generic.hh
+++ b/dune/gdt/local/integrands/generic.hh
@@ -39,10 +39,11 @@ public:
                                                          const XT::Common::Parameter& /*param*/)>;
   using GenericPostBindFunctionType = std::function<void(const E& /*ele*/)>;
 
-  GenericLocalUnaryElementIntegrand(GenericOrderFunctionType order_function,
-                                    GenericEvaluateFunctionType evaluate_function,
-                                    GenericPostBindFunctionType post_bind_function = [](const E&) {},
-                                    const XT::Common::ParameterType& param_type = {})
+  GenericLocalUnaryElementIntegrand(
+      GenericOrderFunctionType order_function,
+      GenericEvaluateFunctionType evaluate_function,
+      GenericPostBindFunctionType post_bind_function = [](const E&) {},
+      const XT::Common::ParameterType& param_type = {})
     : BaseType(param_type)
     , order_(order_function)
     , evaluate_(evaluate_function)
@@ -126,10 +127,11 @@ public:
                                                          const XT::Common::Parameter& /*param*/)>;
   using GenericPostBindFunctionType = std::function<void(const E& /*ele*/)>;
 
-  GenericLocalBinaryElementIntegrand(GenericOrderFunctionType order_function,
-                                     GenericEvaluateFunctionType evaluate_function,
-                                     GenericPostBindFunctionType post_bind_function = [](const E&) {},
-                                     const XT::Common::ParameterType& param_type = {})
+  GenericLocalBinaryElementIntegrand(
+      GenericOrderFunctionType order_function,
+      GenericEvaluateFunctionType evaluate_function,
+      GenericPostBindFunctionType post_bind_function = [](const E&) {},
+      const XT::Common::ParameterType& param_type = {})
     : BaseType(param_type)
     , order_(order_function)
     , evaluate_(evaluate_function)
@@ -210,10 +212,11 @@ public:
                                                          const XT::Common::Parameter& /*param*/)>;
   using GenericPostBindFunctionType = std::function<void(const I& /*ele*/)>;
 
-  GenericLocalBinaryIntersectionIntegrand(GenericOrderFunctionType order_function,
-                                          GenericEvaluateFunctionType evaluate_function,
-                                          GenericPostBindFunctionType post_bind_function = [](const I&) {},
-                                          const XT::Common::ParameterType& param_type = {})
+  GenericLocalBinaryIntersectionIntegrand(
+      GenericOrderFunctionType order_function,
+      GenericEvaluateFunctionType evaluate_function,
+      GenericPostBindFunctionType post_bind_function = [](const I&) {},
+      const XT::Common::ParameterType& param_type = {})
     : BaseType(param_type)
     , order_(order_function)
     , evaluate_(evaluate_function)

--- a/dune/gdt/operators/reconstruction/linear.hh
+++ b/dune/gdt/operators/reconstruction/linear.hh
@@ -179,7 +179,7 @@ public:
                                                       const XT::Common::Parameter& param,
                                                       const bool flux_is_affine = false)
     : slope_functor_(std::make_unique<SlopeFunctorType>(
-          grid_view, source_values, boundary_values, analytical_flux, slope, param, flux_is_affine))
+        grid_view, source_values, boundary_values, analytical_flux, slope, param, flux_is_affine))
     , reconstructed_function_(reconstructed_function)
   {}
 
@@ -246,7 +246,7 @@ public:
                                              const XT::Common::Parameter& param,
                                              const bool flux_is_affine = false)
     : slope_functor_(std::make_unique<SlopeFunctorType>(
-          target_space.grid_view(), source_values, boundary_values, analytical_flux, slope, param, flux_is_affine))
+        target_space.grid_view(), source_values, boundary_values, analytical_flux, slope, param, flux_is_affine))
     , target_space_(target_space)
     , target_vector_(target_vector)
     , target_(target_space_, target_vector_, "range")

--- a/dune/gdt/test/burgers/base.hh
+++ b/dune/gdt/test/burgers/base.hh
@@ -37,11 +37,12 @@ struct BurgersProblem
   const double T_end;
 
   BurgersProblem()
-    : flux(2,
-           [&](const auto& u, const auto& /*param*/) { return 0.5 * u * u; },
-           "burgers",
-           {},
-           [&](const auto& u, const auto& /*param*/) { return u; })
+    : flux(
+        2,
+        [&](const auto& u, const auto& /*param*/) { return 0.5 * u * u; },
+        "burgers",
+        {},
+        [&](const auto& u, const auto& /*param*/) { return u; })
     , T_end(1.)
   {}
 
@@ -54,11 +55,12 @@ struct BurgersProblem
   DiscreteFunction<Vector, GV> make_initial_values(const SpaceInterface<GV, 1>& space) const
   {
     // TODO: Use generic interpolate once implemented?
-    return default_interpolation<Vector>(3,
-                                         [&](const auto& xx, const auto& /*mu*/) {
-                                           return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
-                                         },
-                                         space);
+    return default_interpolation<Vector>(
+        3,
+        [&](const auto& xx, const auto& /*mu*/) {
+          return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
+        },
+        space);
   }
 }; // struct BurgersProblem
 

--- a/dune/gdt/test/instationary-eocstudies/base.hh
+++ b/dune/gdt/test/instationary-eocstudies/base.hh
@@ -80,13 +80,14 @@ protected:
   using O = OperatorInterface<M, GV, m>;
 
 public:
-  InstationaryEocStudy(const double T_end,
-                       const std::string timestepping,
-                       std::function<void(const DiscreteBochnerFunction<V, GV, m>&, const std::string&)> visualizer =
-                           [](const auto& /*solution*/, const auto& /*prefix*/) { /*no visualization by default*/ },
-                       const size_t num_refinements = DXTC_CONFIG_GET("num_refinements", 3),
-                       const size_t num_additional_refinements_for_reference =
-                           DXTC_CONFIG_GET("num_additional_refinements_for_reference", 2))
+  InstationaryEocStudy(
+      const double T_end,
+      const std::string timestepping,
+      std::function<void(const DiscreteBochnerFunction<V, GV, m>&, const std::string&)> visualizer =
+          [](const auto& /*solution*/, const auto& /*prefix*/) { /*no visualization by default*/ },
+      const size_t num_refinements = DXTC_CONFIG_GET("num_refinements", 3),
+      const size_t num_additional_refinements_for_reference =
+          DXTC_CONFIG_GET("num_additional_refinements_for_reference", 2))
     : T_end_(T_end)
     , timestepping_(timestepping)
     , num_refinements_(num_refinements)

--- a/dune/gdt/test/inviscid-compressible-flow/base.hh
+++ b/dune/gdt/test/inviscid-compressible-flow/base.hh
@@ -49,11 +49,12 @@ struct InviscidCompressibleFlowEulerProblem
 
   InviscidCompressibleFlowEulerProblem()
     : euler_tools(1.4) // air or water at roughly 20 deg Cels.
-    , flux(euler_tools.flux_order(),
-           [&](const auto& u, const auto& /*param*/) { return euler_tools.flux(u); },
-           "euler_flux",
-           {},
-           [&](const auto& u, const auto& /*param*/) { return euler_tools.flux_jacobian(u); })
+    , flux(
+          euler_tools.flux_order(),
+          [&](const auto& u, const auto& /*param*/) { return euler_tools.flux(u); },
+          "euler_flux",
+          {},
+          [&](const auto& u, const auto& /*param*/) { return euler_tools.flux_jacobian(u); })
     , T_end(1.)
   {}
 
@@ -107,19 +108,20 @@ protected:
 public:
   InviscidCompressibleFlowEulerTest(const std::string timestepping, const size_t num_refinements = 2)
     : Problem(new InviscidCompressibleFlowEulerProblem<G>())
-    , BaseType(this->access().T_end,
-               timestepping,
-               [&](const auto& solution, const auto& prefix) {
-                 for (size_t ii = 0; ii < this->visualization_steps_; ++ii) {
-                   const double time = ii * (this->T_end_ / this->visualization_steps_);
-                   const auto u_t = solution.evaluate(time);
-                   this->access().euler_tools.visualize(u_t,
-                                                        u_t.space().grid_view(),
-                                                        XT::Common::Test::get_unique_test_name() + "__" + prefix,
-                                                        XT::Common::to_string(ii));
-                 }
-               },
-               num_refinements)
+    , BaseType(
+          this->access().T_end,
+          timestepping,
+          [&](const auto& solution, const auto& prefix) {
+            for (size_t ii = 0; ii < this->visualization_steps_; ++ii) {
+              const double time = ii * (this->T_end_ / this->visualization_steps_);
+              const auto u_t = solution.evaluate(time);
+              this->access().euler_tools.visualize(u_t,
+                                                   u_t.space().grid_view(),
+                                                   XT::Common::Test::get_unique_test_name() + "__" + prefix,
+                                                   XT::Common::to_string(ii));
+            }
+          },
+          num_refinements)
     , visualization_steps_(0)
     , boundary_treatment("")
   {}
@@ -135,12 +137,13 @@ protected:
     if (boundary_treatment == "inflow_from_the_left_by_heuristic_euler_treatment_impermeable_wall_right") {
       const auto& euler_tools = this->access().euler_tools;
       // TODO: Use generic interpolate once implemented?
-      return default_interpolation<V>(0,
-                                      [&](const auto& /*xx*/, const auto& /*param*/) {
-                                        return euler_tools.conservative(
-                                            /*density=*/0.5, /*velocity=*/0., /*pressure=*/0.4);
-                                      },
-                                      space);
+      return default_interpolation<V>(
+          0,
+          [&](const auto& /*xx*/, const auto& /*param*/) {
+            return euler_tools.conservative(
+                /*density=*/0.5, /*velocity=*/0., /*pressure=*/0.4);
+          },
+          space);
     } else
       return this->access().template make_initial_values<V>(space);
   } // ... make_initial_values(...)
@@ -356,7 +359,7 @@ protected:
     const auto fv_dt =
         (this->boundary_treatment == "inflow_from_the_left_by_heuristic_euler_treatment_impermeable_wall_right")
             ? estimate_dt_for_hyperbolic_system(
-                  space.grid_view(), u_0, this->flux(), /*boundary_data_range=*/{{0.5, 0., 0.4}, {1.5, 0.5, 0.4}})
+                space.grid_view(), u_0, this->flux(), /*boundary_data_range=*/{{0.5, 0., 0.4}, {1.5, 0.5, 0.4}})
             : estimate_dt_for_hyperbolic_system(space.grid_view(), u_0, this->flux());
     auto dt = fv_dt;
     if (this->space_type_ != "fv") {

--- a/dune/gdt/test/linear-transport/base.hh
+++ b/dune/gdt/test/linear-transport/base.hh
@@ -41,11 +41,12 @@ struct LinearTransportProblem
 
   LinearTransportProblem()
     : direction(XT::Common::from_string<DomainType>("[1 0 0]"))
-    , flux(1,
-           [&](const auto& u, const auto& /*param*/) { return direction * u; },
-           "linear_transport",
-           {},
-           [&](const auto& /*u*/, const auto& /*param*/) { return direction; })
+    , flux(
+          1,
+          [&](const auto& u, const auto& /*param*/) { return direction * u; },
+          "linear_transport",
+          {},
+          [&](const auto& /*u*/, const auto& /*param*/) { return direction; })
     , T_end(1.)
   {}
 

--- a/dune/gdt/test/momentmodels/entropyflux_implementations.hh
+++ b/dune/gdt/test/momentmodels/entropyflux_implementations.hh
@@ -979,7 +979,7 @@ public:
                                           const size_t k_max,
                                           const RangeFieldType epsilon)
     : BaseType(
-          basis_functions, tau, disable_realizability_check, epsilon_gamma, chi, xi, r_sequence, k_0, k_max, epsilon)
+        basis_functions, tau, disable_realizability_check, epsilon_gamma, chi, xi, r_sequence, k_0, k_max, epsilon)
     , T_minus_one_(std::make_unique<MatrixType>())
   {
     XT::LA::eye_matrix(*T_minus_one_);
@@ -1208,7 +1208,7 @@ public:
                                           const size_t k_max,
                                           const RangeFieldType epsilon)
     : BaseType(
-          basis_functions, tau, disable_realizability_check, epsilon_gamma, chi, xi, r_sequence, k_0, k_max, epsilon)
+        basis_functions, tau, disable_realizability_check, epsilon_gamma, chi, xi, r_sequence, k_0, k_max, epsilon)
   {}
 
   std::unique_ptr<AlphaReturnType> get_alpha(const DomainType& u) const
@@ -1565,11 +1565,11 @@ public:
       *phi *= 1. / density;
 
     // if value has already been calculated for these values, skip computation
-    RangeFieldType tau_prime = rescale ? std::min(tau_
-                                                      / ((1 + std::sqrt(basis_dimRange) * phi->two_norm()) * density
-                                                         + std::sqrt(basis_dimRange) * tau_),
-                                                  tau_)
-                                       : tau_;
+    RangeFieldType tau_prime =
+        rescale ? std::min(
+            tau_ / ((1 + std::sqrt(basis_dimRange) * phi->two_norm()) * density + std::sqrt(basis_dimRange) * tau_),
+            tau_)
+                : tau_;
 
     // calculate moment vector for isotropic distribution
     auto u_iso = std::make_unique<BlockVectorType>(basis_functions_.u_iso());
@@ -2566,11 +2566,11 @@ public:
     DomainType alpha_one;
     basis_functions_.alpha_one(alpha_one);
 
-    RangeFieldType tau_prime = rescale ? std::min(tau_
-                                                      / ((1 + std::sqrt(basis_dimRange) * phi.two_norm()) * density
-                                                         + std::sqrt(basis_dimRange) * tau_),
-                                                  tau_)
-                                       : tau_;
+    RangeFieldType tau_prime =
+        rescale ? std::min(
+            tau_ / ((1 + std::sqrt(basis_dimRange) * phi.two_norm()) * density + std::sqrt(basis_dimRange) * tau_),
+            tau_)
+                : tau_;
 
     // calculate moment vector for isotropic distribution
     DomainType u_iso;
@@ -3222,11 +3222,9 @@ public:
     basis_functions_.alpha_one(alpha_one);
 
     RangeFieldType tau_prime =
-        rescale
-            ? std::min(
-                  tau_ / ((1 + std::sqrt(basis_dimRange) * phi.l2_norm()) * density + std::sqrt(basis_dimRange) * tau_),
-                  tau_)
-            : tau_;
+        rescale ? std::min(
+            tau_ / ((1 + std::sqrt(basis_dimRange) * phi.l2_norm()) * density + std::sqrt(basis_dimRange) * tau_), tau_)
+                : tau_;
     thread_local SparseMatrixType H(basis_dimRange, basis_dimRange, pattern_, 0);
 #    if HAVE_EIGEN
     typedef ::Eigen::SparseMatrix<RangeFieldType, ::Eigen::ColMajor> ColMajorBackendType;

--- a/dune/gdt/test/momentmodels/entropyflux_kineticcoords.hh
+++ b/dune/gdt/test/momentmodels/entropyflux_kineticcoords.hh
@@ -75,7 +75,7 @@ public:
       const size_t k_max = 1000,
       const RangeFieldType epsilon = std::pow(2, -52))
     : implementation_(std::make_shared<ImplementationType>(
-          basis_functions, tau, disable_realizability_check, epsilon_gamma, chi, xi, r_sequence, k_0, k_max, epsilon))
+        basis_functions, tau, disable_realizability_check, epsilon_gamma, chi, xi, r_sequence, k_0, k_max, epsilon))
   {}
 
   explicit EntropyBasedFluxEntropyCoordsFunction(EntropyBasedFluxFunction<GridViewType, MomentBasis>& other)

--- a/dune/gdt/test/momentmodels/kinetictransport/testcases.hh
+++ b/dune/gdt/test/momentmodels/kinetictransport/testcases.hh
@@ -313,10 +313,10 @@ struct SourceBeamMnExpectedResults<LegendreMomentBasis<double, double, 7>, recon
 template <bool reconstruct>
 struct SourceBeamMnExpectedResults<LegendreMomentBasis<double, double, 7>, reconstruct, true>
 {
-  static constexpr double l1norm = reconstruct ? 281.53354213834325 : 315.13471927598744;
-  static constexpr double l2norm = reconstruct ? 492.8631341026487 : 513.73456040950032;
+  static constexpr double l1norm = reconstruct ? 281.49717291377885 : 315.13471927598744;
+  static constexpr double l2norm = reconstruct ? 492.78959375804538 : 513.73456040950032;
   static constexpr double linfnorm = reconstruct ? 1824.235113480062 : 1820.2785947776988;
-  static constexpr double tol = 1e-4;
+  static constexpr double tol = 1e-3;
 };
 
 template <bool reconstruct, bool kinetic_scheme>

--- a/dune/gdt/test/stationary-eocstudies/base.hh
+++ b/dune/gdt/test/stationary-eocstudies/base.hh
@@ -80,14 +80,15 @@ protected:
 public:
   using E = XT::Grid::extract_entity_t<GV>;
 
-  StationaryEocStudy(std::function<void(const DF&, const std::string&)> visualizer =
-                         [](const auto& solution, const auto& prefix) {
-                           if (DXTC_TEST_CONFIG_GET("setup.visualize", false))
-                             solution.visualize(prefix);
-                         },
-                     const size_t num_refinements = DXTC_TEST_CONFIG_GET("setup.num_refinements", 3),
-                     const size_t num_additional_refinements_for_reference =
-                         DXTC_TEST_CONFIG_GET("setup.num_additional_refinements_for_reference", 2))
+  StationaryEocStudy(
+      std::function<void(const DF&, const std::string&)> visualizer =
+          [](const auto& solution, const auto& prefix) {
+            if (DXTC_TEST_CONFIG_GET("setup.visualize", false))
+              solution.visualize(prefix);
+          },
+      const size_t num_refinements = DXTC_TEST_CONFIG_GET("setup.num_refinements", 3),
+      const size_t num_additional_refinements_for_reference =
+          DXTC_TEST_CONFIG_GET("setup.num_additional_refinements_for_reference", 2))
     : num_refinements_(num_refinements)
     , num_additional_refinements_for_reference_(num_additional_refinements_for_reference)
     , visualize_(visualizer)

--- a/dune/gdt/tools/timestepper/adaptive-rungekutta.hh
+++ b/dune/gdt/tools/timestepper/adaptive-rungekutta.hh
@@ -77,28 +77,22 @@ class AdaptiveButcherArrayProvider<RangeFieldType, TimeStepperMethods::bogacki_s
 public:
   static Dune::DynamicMatrix<RangeFieldType> A()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicMatrix<RangeFieldType>>(
-        "[0 0 0 0; 0.5 0 0 0; 0 0.75 0 0; " + Dune::XT::Common::to_string(2.0 / 9.0, 15) + " "
-        + Dune::XT::Common::to_string(1.0 / 3.0, 15) + " " + Dune::XT::Common::to_string(4.0 / 9.0, 15) + " 0]");
+    return {{0., 0., 0., 0.}, {1. / 2., 0., 0., 0.}, {0, 3. / 4., 0., 0.}, {2. / 9., 1. / 3., 4. / 9., 0.}};
   }
 
   static Dune::DynamicVector<RangeFieldType> b_1()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>(
-        "[" + Dune::XT::Common::to_string(2.0 / 9.0, 15) + " " + Dune::XT::Common::to_string(1.0 / 3.0, 15) + " "
-        + Dune::XT::Common::to_string(4.0 / 9.0, 15) + " 0]");
+    return {2. / 9., 1. / 3., 4. / 9., 0.};
   }
 
   static Dune::DynamicVector<RangeFieldType> b_2()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>(
-        "[" + Dune::XT::Common::to_string(7.0 / 24.0, 15) + " " + Dune::XT::Common::to_string(1.0 / 4.0, 15) + " "
-        + Dune::XT::Common::to_string(1.0 / 3.0, 15) + " " + Dune::XT::Common::to_string(1.0 / 8.0, 15) + "]");
+    return {7. / 24., 1. / 4., 1. / 3., 1. / 8.};
   }
 
   static Dune::DynamicVector<RangeFieldType> c()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>("[0.5 0.75 1 0]");
+    return {0, 0.5, 0.75, 1.};
   }
 
   // lower one of the two orders
@@ -112,42 +106,28 @@ class AdaptiveButcherArrayProvider<RangeFieldType, TimeStepperMethods::dormand_p
 public:
   static Dune::DynamicMatrix<RangeFieldType> A()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicMatrix<RangeFieldType>>(
-        std::string("[0 0 0 0 0 0 0;") + " 0.2 0 0 0 0 0 0;" + " 0.075 0.225 0 0 0 0 0;" + " "
-        + Dune::XT::Common::to_string(44.0 / 45.0, 15) + " " + Dune::XT::Common::to_string(-56.0 / 15.0, 15) + " "
-        + Dune::XT::Common::to_string(32.0 / 9.0, 15) + " 0 0 0 0;" + " "
-        + Dune::XT::Common::to_string(19372.0 / 6561.0, 15) + " " + Dune::XT::Common::to_string(-25360.0 / 2187.0, 15)
-        + " " + Dune::XT::Common::to_string(64448.0 / 6561.0, 15) + " "
-        + Dune::XT::Common::to_string(-212.0 / 729.0, 15) + " 0 0 0;" + " "
-        + Dune::XT::Common::to_string(9017.0 / 3168.0, 15) + " " + Dune::XT::Common::to_string(-355.0 / 33.0, 15) + " "
-        + Dune::XT::Common::to_string(46732.0 / 5247.0, 15) + " " + Dune::XT::Common::to_string(49.0 / 176.0, 15) + " "
-        + Dune::XT::Common::to_string(-5103.0 / 18656.0, 15) + " 0 0;" + " "
-        + Dune::XT::Common::to_string(35.0 / 384.0, 15) + " 0 " + Dune::XT::Common::to_string(500.0 / 1113.0, 15) + " "
-        + Dune::XT::Common::to_string(125.0 / 192.0, 15) + " " + Dune::XT::Common::to_string(-2187.0 / 6784.0, 15) + " "
-        + Dune::XT::Common::to_string(11.0 / 84.0, 15) + " 0]");
+    return {{0., 0., 0., 0., 0., 0., 0.},
+            {1. / 5., 0., 0., 0., 0., 0., 0.},
+            {3. / 40., 9. / 40., 0., 0., 0., 0., 0.},
+            {44. / 45., -56. / 15., 32. / 9., 0., 0., 0., 0.},
+            {19372. / 6561., -25360. / 2187., 64448. / 6561., -212. / 729., 0., 0., 0.},
+            {9017. / 3168., -355. / 33., 46732. / 5247., 49. / 176., -5103. / 18656., 0., 0.},
+            {35. / 384., 0., 500. / 1113., 125. / 192., -2187. / 6784., 11. / 84., 0.}};
   }
 
   static Dune::DynamicVector<RangeFieldType> b_1()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>(
-        "[" + Dune::XT::Common::to_string(35.0 / 384.0, 15) + " 0 " + Dune::XT::Common::to_string(500.0 / 1113.0, 15)
-        + " " + Dune::XT::Common::to_string(125.0 / 192.0, 15) + " " + Dune::XT::Common::to_string(-2187.0 / 6784.0, 15)
-        + " " + Dune::XT::Common::to_string(11.0 / 84.0, 15) + " 0]");
+    return {35. / 384., 0., 500. / 1113., 125. / 192., -2187. / 6784., 11. / 84., 0.};
   }
 
   static Dune::DynamicVector<RangeFieldType> b_2()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>(
-        "[" + Dune::XT::Common::to_string(5179.0 / 57600.0, 15) + " 0 "
-        + Dune::XT::Common::to_string(7571.0 / 16695.0, 15) + " " + Dune::XT::Common::to_string(393.0 / 640.0, 15) + " "
-        + Dune::XT::Common::to_string(-92097.0 / 339200.0, 15) + " " + Dune::XT::Common::to_string(187.0 / 2100.0, 15)
-        + " " + Dune::XT::Common::to_string(1.0 / 40.0, 15) + "]");
+    return {5179. / 57600., 0., 7571. / 16695., 393. / 640., -92097. / 339200., 187. / 2100., 1. / 40};
   }
 
   static Dune::DynamicVector<RangeFieldType> c()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>(
-        "[0 0.2 0.3 0.8 " + Dune::XT::Common::to_string(8.0 / 9.0, 15) + " 1 1]");
+    return {0., 1. / 5., 3. / 10., 4. / 5., 8. / 9., 1., 1.};
   }
 
   // lower one of the two orders

--- a/dune/gdt/tools/timestepper/explicit-rungekutta.hh
+++ b/dune/gdt/tools/timestepper/explicit-rungekutta.hh
@@ -65,17 +65,17 @@ struct ButcherArrayProvider<RangeFieldType, TimeStepperMethods::explicit_euler>
 {
   static Dune::DynamicMatrix<RangeFieldType> A()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicMatrix<RangeFieldType>>("[0]");
+    return {{0.}};
   }
 
   static Dune::DynamicVector<RangeFieldType> b()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>("[1]");
+    return {1.};
   }
 
   static Dune::DynamicVector<RangeFieldType> c()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>("[0]");
+    return {0.};
   }
 };
 
@@ -85,17 +85,17 @@ struct ButcherArrayProvider<RangeFieldType, TimeStepperMethods::explicit_rungeku
 {
   static Dune::DynamicMatrix<RangeFieldType> A()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicMatrix<RangeFieldType>>("[0 0; 1 0]");
+    return {{0., 0.}, {1., 0.}};
   }
 
   static Dune::DynamicVector<RangeFieldType> b()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>("[0.5 0.5]");
+    return {0.5, 0.5};
   }
 
   static Dune::DynamicVector<RangeFieldType> c()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>("[0 1]");
+    return {0., 1.};
   }
 };
 
@@ -105,19 +105,17 @@ struct ButcherArrayProvider<RangeFieldType, TimeStepperMethods::explicit_rungeku
 {
   static Dune::DynamicMatrix<RangeFieldType> A()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicMatrix<RangeFieldType>>("[0 0 0; 1 0 0; 0.25 0.25 0]");
+    return {{0., 0., 0.}, {1., 0., 0.}, {0.25, 0.25, 0.}};
   }
 
   static Dune::DynamicVector<RangeFieldType> b()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>(
-        "[" + Dune::XT::Common::to_string(1.0 / 6.0, 15) + " " + Dune::XT::Common::to_string(1.0 / 6.0, 15) + " "
-        + Dune::XT::Common::to_string(2.0 / 3.0, 15) + "]");
+    return {1. / 6., 1. / 6., 2. / 3.};
   }
 
   static Dune::DynamicVector<RangeFieldType> c()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>("[0 1 0.5]");
+    return {0., 1., 0.5};
   }
 };
 
@@ -127,20 +125,17 @@ struct ButcherArrayProvider<RangeFieldType, TimeStepperMethods::explicit_rungeku
 {
   static Dune::DynamicMatrix<RangeFieldType> A()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicMatrix<RangeFieldType>>(
-        "[0 0 0 0; 0.5 0 0 0; 0 0.5 0 0; 0 0 1 0]");
+    return {{0., 0., 0., 0.}, {0.5, 0., 0., 0.}, {0., 0.5, 0., 0.}, {0., 0., 1., 0}};
   }
 
   static Dune::DynamicVector<RangeFieldType> b()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>(
-        "[" + Dune::XT::Common::to_string(1.0 / 6.0, 15) + " " + Dune::XT::Common::to_string(1.0 / 3.0, 15) + " "
-        + Dune::XT::Common::to_string(1.0 / 3.0, 15) + " " + Dune::XT::Common::to_string(1.0 / 6.0, 15) + "]");
+    return {1. / 6., 1. / 3., 1. / 3., 1. / 6.};
   }
 
   static Dune::DynamicVector<RangeFieldType> c()
   {
-    return Dune::XT::Common::from_string<Dune::DynamicVector<RangeFieldType>>("[0 0.5 0.5 1]");
+    return {0., 0.5, 0.5, 1.};
   }
 };
 

--- a/examples/mpi_2019_02_talk_on_hyperbolic_equations.cc
+++ b/examples/mpi_2019_02_talk_on_hyperbolic_equations.cc
@@ -211,14 +211,15 @@ GTEST_TEST(MPI201902TalkExamples, instationary_heat_equation)
   auto time_loop = [&](const double& T_end, const double& dt) {
     XT::LA::ListVectorArray<V> solution(cg_space.mapper().size(), /*length=*/0, /*reserve=*/std::ceil(T_end / (dt)));
     // initial values
-    solution.append(default_interpolation<V>(0,
-                                             [](const auto& xx, const auto& /*param*/) {
-                                               if (0.25 <= xx[0] && xx[0] <= 0.5)
-                                                 return 1.;
-                                               else
-                                                 return 0.;
-                                             },
-                                             cg_space)
+    solution.append(default_interpolation<V>(
+                        0,
+                        [](const auto& xx, const auto& /*param*/) {
+                          if (0.25 <= xx[0] && xx[0] <= 0.5)
+                            return 1.;
+                          else
+                            return 0.;
+                        },
+                        cg_space)
                         .dofs()
                         .vector(),
                     {"_t", 0.});
@@ -262,22 +263,24 @@ GTEST_TEST(MPI201902TalkExamples, linear_transport)
 
   auto V_h_0 = make_finite_volume_space(grid_view);
 
-  const XT::Functions::GenericFunction<1, d, 1> f(1,
-                                                  [&](const auto& w, const auto& /*param*/) { return 1. * w; },
-                                                  "transport_to_the_right",
-                                                  {},
-                                                  [&](const auto& /*w*/, const auto& /*param*/) { return 1.; });
+  const XT::Functions::GenericFunction<1, d, 1> f(
+      1,
+      [&](const auto& w, const auto& /*param*/) { return 1. * w; },
+      "transport_to_the_right",
+      {},
+      [&](const auto& /*w*/, const auto& /*param*/) { return 1.; });
   const NumericalUpwindFlux<I, d, 1> g(f);
   auto L_h = make_advection_fv_operator<M>(grid_view, g, V_h_0, V_h_0);
 
-  auto w_0 = default_interpolation<V>(0,
-                                      [](const auto& xx, const auto& /*param*/) {
-                                        if (0.25 <= xx[0] && xx[0] <= 0.5)
-                                          return 1.;
-                                        else
-                                          return 0.;
-                                      },
-                                      V_h_0);
+  auto w_0 = default_interpolation<V>(
+      0,
+      [](const auto& xx, const auto& /*param*/) {
+        if (0.25 <= xx[0] && xx[0] <= 0.5)
+          return 1.;
+        else
+          return 0.;
+      },
+      V_h_0);
 
   // explicit, the right choice
   const double T_end = 1.;
@@ -306,19 +309,21 @@ GTEST_TEST(MPI201902TalkExamples, burgers)
 
   auto V_h_0 = make_finite_volume_space(grid_view);
 
-  const XT::Functions::GenericFunction<1, d, 1> f(2,
-                                                  [&](const auto& w, const auto& /*param*/) { return 0.5 * w * w; },
-                                                  "burgers",
-                                                  {},
-                                                  [&](const auto& w, const auto& /*param*/) { return w; });
+  const XT::Functions::GenericFunction<1, d, 1> f(
+      2,
+      [&](const auto& w, const auto& /*param*/) { return 0.5 * w * w; },
+      "burgers",
+      {},
+      [&](const auto& w, const auto& /*param*/) { return w; });
   const NumericalUpwindFlux<I, d, 1> g(f);
   auto L_h = make_advection_fv_operator<M>(grid_view, g, V_h_0, V_h_0);
 
-  auto w_0 = default_interpolation<V>(3,
-                                      [&](const auto& xx, const auto& /*mu*/) {
-                                        return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
-                                      },
-                                      V_h_0);
+  auto w_0 = default_interpolation<V>(
+      3,
+      [&](const auto& xx, const auto& /*mu*/) {
+        return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
+      },
+      V_h_0);
 
   // explicit
   const double T_end = 1.;
@@ -343,25 +348,27 @@ GTEST_TEST(MPI201902TalkExamples, linear_transport__central_differences)
 
   auto V_h_0 = make_finite_volume_space(grid_view);
 
-  const XT::Functions::GenericFunction<1, d, 1> f(1,
-                                                  [&](const auto& w, const auto& /*param*/) { return 1. * w; },
-                                                  "transport_to_the_right",
-                                                  {},
-                                                  [&](const auto& /*w*/, const auto& /*param*/) { return 1.; });
+  const XT::Functions::GenericFunction<1, d, 1> f(
+      1,
+      [&](const auto& w, const auto& /*param*/) { return 1. * w; },
+      "transport_to_the_right",
+      {},
+      [&](const auto& /*w*/, const auto& /*param*/) { return 1.; });
   const GenericNumericalFlux<I, d, 1> g(
       f, [&](const auto&, const auto&, const auto& w_minus, const auto& w_plus, const auto& n, const auto& /*param*/) {
         return 0.5 * (f.evaluate(w_minus) + f.evaluate(w_plus)) * n;
       });
   auto L_h = make_advection_fv_operator<M>(grid_view, g, V_h_0, V_h_0);
 
-  auto w_0 = default_interpolation<V>(0,
-                                      [](const auto& xx, const auto& /*param*/) {
-                                        if (0.25 <= xx[0] && xx[0] <= 0.5)
-                                          return 1.;
-                                        else
-                                          return 0.;
-                                      },
-                                      V_h_0);
+  auto w_0 = default_interpolation<V>(
+      0,
+      [](const auto& xx, const auto& /*param*/) {
+        if (0.25 <= xx[0] && xx[0] <= 0.5)
+          return 1.;
+        else
+          return 0.;
+      },
+      V_h_0);
 
   // explicit, the right choice
   const double T_end = 1.;
@@ -438,20 +445,22 @@ GTEST_TEST(MPI201902TalkExamples, burgers_p1_unstable)
 
   const DiscontinuousLagrangeSpace<GV> V_h_1(grid_view, 1);
 
-  const XT::Functions::GenericFunction<1, d, 1> f(2,
-                                                  [&](const auto& w, const auto& /*param*/) { return 0.5 * w * w; },
-                                                  "burgers",
-                                                  {},
-                                                  [&](const auto& w, const auto& /*param*/) { return w; });
+  const XT::Functions::GenericFunction<1, d, 1> f(
+      2,
+      [&](const auto& w, const auto& /*param*/) { return 0.5 * w * w; },
+      "burgers",
+      {},
+      [&](const auto& w, const auto& /*param*/) { return w; });
   const NumericalUpwindFlux<I, d, 1> g(f);
   // unstable DG operator
   const AdvectionDgOperator<M, GV> L_h(grid_view, g, V_h_1, V_h_1, XT::Grid::ApplyOn::NoIntersections<GV>(), 0., 0.);
 
-  auto w_0 = default_interpolation<V>(3,
-                                      [&](const auto& xx, const auto& /*mu*/) {
-                                        return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
-                                      },
-                                      V_h_1);
+  auto w_0 = default_interpolation<V>(
+      3,
+      [&](const auto& xx, const auto& /*mu*/) {
+        return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
+      },
+      V_h_1);
 
   const double T_end = 1.;
   const double fv_dt = estimate_dt_for_hyperbolic_system(grid_view, w_0, f);
@@ -469,11 +478,12 @@ GTEST_TEST(MPI201902TalkExamples, burgers_shock_capturing)
   using GV = decltype(grid_view);
   using I = XT::Grid::extract_intersection_t<GV>;
 
-  const XT::Functions::GenericFunction<1, d, 1> f(2,
-                                                  [&](const auto& w, const auto& /*param*/) { return 0.5 * w * w; },
-                                                  "burgers",
-                                                  {},
-                                                  [&](const auto& w, const auto& /*param*/) { return w; });
+  const XT::Functions::GenericFunction<1, d, 1> f(
+      2,
+      [&](const auto& w, const auto& /*param*/) { return 0.5 * w * w; },
+      "burgers",
+      {},
+      [&](const auto& w, const auto& /*param*/) { return w; });
   const NumericalEngquistOsherFlux<I, d, 1> g(f);
 
   auto perform_simulation = [&](const int p, const std::string& prefix, const double& CFL_factor = 0.99) {
@@ -482,11 +492,12 @@ GTEST_TEST(MPI201902TalkExamples, burgers_shock_capturing)
     // stabilized DG operator
     const AdvectionDgOperator<M, GV> L_h(grid_view, g, V_h_p, V_h_p);
 
-    auto w_0 = default_interpolation<V>(3,
-                                        [&](const auto& xx, const auto& /*mu*/) {
-                                          return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
-                                        },
-                                        V_h_p);
+    auto w_0 = default_interpolation<V>(
+        3,
+        [&](const auto& xx, const auto& /*mu*/) {
+          return std::exp(-std::pow(xx[0] - 0.33, 2) / (2 * std::pow(0.075, 2)));
+        },
+        V_h_p);
 
     const double T_end = 1.;
     const double fv_dt = estimate_dt_for_hyperbolic_system(grid_view, w_0, f);

--- a/python/dune/gdt/discretefunction/discretefunction.hh
+++ b/python/dune/gdt/discretefunction/discretefunction.hh
@@ -72,20 +72,22 @@ public:
           py::keep_alive<1, 3>());
     c.def(py::init<const S&, const std::string&>(), "space"_a, "name"_a = default_name, py::keep_alive<1, 2>());
     c.def_property_readonly("space", &type::space);
-    c.def_property("dof_vector",
-                   [](const type& self) { return self.dofs().vector(); },
-                   [](type& self, const V& vec) {
-                     DUNE_THROW_IF(vec.size() != self.dofs().vector().size(),
-                                   Exceptions::discrete_function_error,
-                                   "vec.size() = " << vec.size() << "\n   self.dofs().vector().size() = "
-                                                   << self.dofs().vector().size());
-                     self.dofs().vector() = vec;
-                   },
-                   py::return_value_policy::reference_internal);
+    c.def_property(
+        "dof_vector",
+        [](const type& self) { return self.dofs().vector(); },
+        [](type& self, const V& vec) {
+          DUNE_THROW_IF(vec.size() != self.dofs().vector().size(),
+                        Exceptions::discrete_function_error,
+                        "vec.size() = " << vec.size()
+                                        << "\n   self.dofs().vector().size() = " << self.dofs().vector().size());
+          self.dofs().vector() = vec;
+        },
+        py::return_value_policy::reference_internal);
     c.def_property_readonly("name", &type::name);
-    c.def("visualize",
-          [](type& self, const std::string& filename) { return self.visualize(filename, VTK::appendedraw); },
-          "filename"_a);
+    c.def(
+        "visualize",
+        [](type& self, const std::string& filename) { return self.visualize(filename, VTK::appendedraw); },
+        "filename"_a);
 
     // factory
     const std::string factory_name = "make_" + class_name;
@@ -97,11 +99,12 @@ public:
         "name"_a = default_name,
         py::keep_alive<0, 1>(),
         py::keep_alive<0, 2>());
-    m.def(factory_name.c_str(),
-          [](const S& space, const std::string& name) { return make_discrete_function<V>(space, name); },
-          "space"_a,
-          "name"_a = default_name,
-          py::keep_alive<0, 1>());
+    m.def(
+        factory_name.c_str(),
+        [](const S& space, const std::string& name) { return make_discrete_function<V>(space, name); },
+        "space"_a,
+        "name"_a = default_name,
+        py::keep_alive<0, 1>());
 
     return c;
   } // ... bind(...)

--- a/python/dune/gdt/gamm-2019-talk-on-conservative-rb.cc
+++ b/python/dune/gdt/gamm-2019-talk-on-conservative-rb.cc
@@ -311,38 +311,42 @@ PYBIND11_MODULE(gamm_2019_talk_on_conservative_rb, m)
   py::module::import("dune.xt.functions");
   py::module::import("dune.gdt.discretefunction");
 
-  m.def("visualize",
-        [](GP& grid, XT::Functions::FunctionInterface<d>& func, const std::string& filename) {
-          func.visualize(grid.leaf_view(), filename);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "scalar_function"_a,
-        "filename"_a);
-  m.def("visualize",
-        [](GP& grid, XT::Functions::FunctionInterface<d, d, d>& func, const std::string& filename) {
-          func.visualize(grid.leaf_view(), filename);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "matrix_function"_a,
-        "filename"_a);
-  m.def("visualize",
-        [](GP& grid, XT::Functions::GridFunctionInterface<E>& func, const std::string& filename) {
-          func.visualize(grid.leaf_view(), filename);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "scalar_function"_a,
-        "filename"_a);
-  m.def("visualize",
-        [](GP& grid, XT::Functions::GridFunctionInterface<E, d, d>& func, const std::string& filename) {
-          func.visualize(grid.leaf_view(), filename);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "scalar_function"_a,
-        "filename"_a);
+  m.def(
+      "visualize",
+      [](GP& grid, XT::Functions::FunctionInterface<d>& func, const std::string& filename) {
+        func.visualize(grid.leaf_view(), filename);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "scalar_function"_a,
+      "filename"_a);
+  m.def(
+      "visualize",
+      [](GP& grid, XT::Functions::FunctionInterface<d, d, d>& func, const std::string& filename) {
+        func.visualize(grid.leaf_view(), filename);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "matrix_function"_a,
+      "filename"_a);
+  m.def(
+      "visualize",
+      [](GP& grid, XT::Functions::GridFunctionInterface<E>& func, const std::string& filename) {
+        func.visualize(grid.leaf_view(), filename);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "scalar_function"_a,
+      "filename"_a);
+  m.def(
+      "visualize",
+      [](GP& grid, XT::Functions::GridFunctionInterface<E, d, d>& func, const std::string& filename) {
+        func.visualize(grid.leaf_view(), filename);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "scalar_function"_a,
+      "filename"_a);
 
   py::class_<GP> grid_provider(m, "GridProvider", "GridProvider");
   grid_provider.def(py::init([](const FieldVector<double, d>& lower_left,
@@ -370,291 +374,310 @@ PYBIND11_MODULE(gamm_2019_talk_on_conservative_rb, m)
   rtn_space.def_property_readonly("dimDomain", [](RTN& /*self*/) { return d; });
   rtn_space.def_property_readonly("num_DoFs", [](RTN& self) { return self.mapper().size(); });
 
-  m.def("make_discrete_function",
-        [](DG& dg_space, V& vec, const std::string& name) { return ScalarDF(dg_space, vec, name); },
-        "dg_space"_a,
-        "DoF_vector"_a,
-        "name"_a);
-  m.def("make_discrete_function",
-        [](RTN& rtn_space, V& vec, const std::string& name) { return VectorDF(rtn_space, vec, name); },
-        "rtn_space"_a,
-        "DoF_vector"_a,
-        "name"_a);
+  m.def(
+      "make_discrete_function",
+      [](DG& dg_space, V& vec, const std::string& name) { return ScalarDF(dg_space, vec, name); },
+      "dg_space"_a,
+      "DoF_vector"_a,
+      "name"_a);
+  m.def(
+      "make_discrete_function",
+      [](RTN& rtn_space, V& vec, const std::string& name) { return VectorDF(rtn_space, vec, name); },
+      "rtn_space"_a,
+      "DoF_vector"_a,
+      "name"_a);
 
-  m.def("prolong",
-        [](DG& coarse_dg_space, V& coarse_pressure, DG& fine_dg_space) {
-          auto fine_pressure = prolong<V>(make_discrete_function(coarse_dg_space, coarse_pressure), fine_dg_space);
-          return std::make_unique<V>(std::move(fine_pressure.dofs().vector()));
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "coarse_dg_space"_a,
-        "coarse_pressure"_a,
-        "fine_dg_space"_a);
-  m.def("prolong",
-        [](RTN& coarse_rtn_space, V& coarse_flux, RTN& fine_rtn_space) {
-          auto fine_flux = prolong<V>(make_discrete_function(coarse_rtn_space, coarse_flux), fine_rtn_space);
-          return std::make_unique<V>(std::move(fine_flux.dofs().vector()));
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "coarse_rtn_space"_a,
-        "coarse_flux"_a,
-        "fine_rtn_space"_a);
+  m.def(
+      "prolong",
+      [](DG& coarse_dg_space, V& coarse_pressure, DG& fine_dg_space) {
+        auto fine_pressure = prolong<V>(make_discrete_function(coarse_dg_space, coarse_pressure), fine_dg_space);
+        return std::make_unique<V>(std::move(fine_pressure.dofs().vector()));
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "coarse_dg_space"_a,
+      "coarse_pressure"_a,
+      "fine_dg_space"_a);
+  m.def(
+      "prolong",
+      [](RTN& coarse_rtn_space, V& coarse_flux, RTN& fine_rtn_space) {
+        auto fine_flux = prolong<V>(make_discrete_function(coarse_rtn_space, coarse_flux), fine_rtn_space);
+        return std::make_unique<V>(std::move(fine_flux.dofs().vector()));
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "coarse_rtn_space"_a,
+      "coarse_flux"_a,
+      "fine_rtn_space"_a);
 
-  m.def("assemble_SWIPDG_matrix",
-        [](DG& space, XT::Functions::FunctionInterface<d>& diffusion_factor, const bool parallel) {
-          const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
-              XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
-          return assemble_SWIPDG_matrix(
-              space, diffusion_factor.as_grid_function<E>(), diffusion_tensor.as_grid_function<E>(), parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "dg_space"_a,
-        "diffusion_factor"_a,
-        "parallel"_a = true);
-  m.def("assemble_SWIPDG_matrix",
-        [](DG& space,
-           XT::Functions::GridFunctionInterface<E>& diffusion_factor,
-           XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
-           const bool parallel) { return assemble_SWIPDG_matrix(space, diffusion_factor, diffusion_tensor, parallel); },
-        py::call_guard<py::gil_scoped_release>(),
-        "dg_space"_a,
-        "diffusion_factor"_a,
-        "diffusion_tensor"_a,
-        "parallel"_a = true);
+  m.def(
+      "assemble_SWIPDG_matrix",
+      [](DG& space, XT::Functions::FunctionInterface<d>& diffusion_factor, const bool parallel) {
+        const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
+            XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
+        return assemble_SWIPDG_matrix(
+            space, diffusion_factor.as_grid_function<E>(), diffusion_tensor.as_grid_function<E>(), parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "dg_space"_a,
+      "diffusion_factor"_a,
+      "parallel"_a = true);
+  m.def(
+      "assemble_SWIPDG_matrix",
+      [](DG& space,
+         XT::Functions::GridFunctionInterface<E>& diffusion_factor,
+         XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
+         const bool parallel) { return assemble_SWIPDG_matrix(space, diffusion_factor, diffusion_tensor, parallel); },
+      py::call_guard<py::gil_scoped_release>(),
+      "dg_space"_a,
+      "diffusion_factor"_a,
+      "diffusion_tensor"_a,
+      "parallel"_a = true);
 
-  m.def("assemble_L2_vector",
-        [](DG& space, XT::Functions::FunctionInterface<d>& force, const bool parallel) {
-          return assemble_L2_vector(space, force.as_grid_function<E>(), parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "dg_space"_a,
-        "force"_a,
-        "parallel"_a = true);
-  m.def("assemble_L2_vector",
-        [](DG& space, XT::Functions::GridFunctionInterface<E>& force, const bool parallel) {
-          return assemble_L2_vector(space, force, parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "dg_space"_a,
-        "force"_a,
-        "parallel"_a = true);
+  m.def(
+      "assemble_L2_vector",
+      [](DG& space, XT::Functions::FunctionInterface<d>& force, const bool parallel) {
+        return assemble_L2_vector(space, force.as_grid_function<E>(), parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "dg_space"_a,
+      "force"_a,
+      "parallel"_a = true);
+  m.def(
+      "assemble_L2_vector",
+      [](DG& space, XT::Functions::GridFunctionInterface<E>& force, const bool parallel) {
+        return assemble_L2_vector(space, force, parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "dg_space"_a,
+      "force"_a,
+      "parallel"_a = true);
 
-  m.def("assemble_energy_semi_product_matrix",
-        [](DG& space, XT::Functions::FunctionInterface<d>& diffusion_factor, const bool parallel) {
-          const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
-              XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
-          return assemble_energy_semi_product_matrix(
-              space, diffusion_factor.as_grid_function<E>(), diffusion_tensor.as_grid_function<E>(), parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "dg_space"_a,
-        "diffusion_factor"_a,
-        "parallel"_a = true);
-  m.def("assemble_energy_semi_product_matrix",
-        [](DG& space,
-           XT::Functions::GridFunctionInterface<E>& diffusion_factor,
-           XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
-           const bool parallel) {
-          return assemble_energy_semi_product_matrix(space, diffusion_factor, diffusion_tensor, parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "dg_space"_a,
-        "diffusion_factor"_a,
-        "diffusion_tensor"_a,
-        "parallel"_a = true);
+  m.def(
+      "assemble_energy_semi_product_matrix",
+      [](DG& space, XT::Functions::FunctionInterface<d>& diffusion_factor, const bool parallel) {
+        const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
+            XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
+        return assemble_energy_semi_product_matrix(
+            space, diffusion_factor.as_grid_function<E>(), diffusion_tensor.as_grid_function<E>(), parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "dg_space"_a,
+      "diffusion_factor"_a,
+      "parallel"_a = true);
+  m.def(
+      "assemble_energy_semi_product_matrix",
+      [](DG& space,
+         XT::Functions::GridFunctionInterface<E>& diffusion_factor,
+         XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
+         const bool parallel) {
+        return assemble_energy_semi_product_matrix(space, diffusion_factor, diffusion_tensor, parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "dg_space"_a,
+      "diffusion_factor"_a,
+      "diffusion_tensor"_a,
+      "parallel"_a = true);
 
-  m.def("assemble_DG_product_matrix",
-        [](DG& space, const bool parallel) {
-          const XT::Functions::ConstantFunction<d> diffusion_factor(1.);
-          const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
-              XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
-          return assemble_DG_product_matrix(
-              space, diffusion_factor.as_grid_function<E>(), diffusion_tensor.as_grid_function<E>(), parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "dg_space"_a,
-        "parallel"_a = true);
-  m.def("assemble_DG_product_matrix",
-        [](DG& space,
-           XT::Functions::GridFunctionInterface<E>& diffusion_factor,
-           XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
-           const bool parallel) {
-          return assemble_DG_product_matrix(space, diffusion_factor, diffusion_tensor, parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "dg_space"_a,
-        "diffusion_factor"_a,
-        "diffusion_tensor"_a,
-        "parallel"_a = true);
+  m.def(
+      "assemble_DG_product_matrix",
+      [](DG& space, const bool parallel) {
+        const XT::Functions::ConstantFunction<d> diffusion_factor(1.);
+        const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
+            XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
+        return assemble_DG_product_matrix(
+            space, diffusion_factor.as_grid_function<E>(), diffusion_tensor.as_grid_function<E>(), parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "dg_space"_a,
+      "parallel"_a = true);
+  m.def(
+      "assemble_DG_product_matrix",
+      [](DG& space,
+         XT::Functions::GridFunctionInterface<E>& diffusion_factor,
+         XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
+         const bool parallel) {
+        return assemble_DG_product_matrix(space, diffusion_factor, diffusion_tensor, parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "dg_space"_a,
+      "diffusion_factor"_a,
+      "diffusion_tensor"_a,
+      "parallel"_a = true);
 
-  m.def("compute_flux_reconstruction",
-        [](GP& grid, DG& dg_space, RTN& rtn_space, XT::Functions::FunctionInterface<d>& diffusion_factor, V& dg_vec) {
-          const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
-              XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
-          return compute_flux_reconstruction(grid,
-                                             dg_space,
-                                             rtn_space,
-                                             diffusion_factor.as_grid_function<E>(),
-                                             diffusion_tensor.as_grid_function<E>(),
-                                             dg_vec);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "dg_space"_a,
-        "rtn_space"_a,
-        "diffusion_factor"_a,
-        "dg_DoF_vector"_a);
-  m.def("compute_flux_reconstruction",
-        [](GP& grid,
-           DG& dg_space,
-           RTN& rtn_space,
-           XT::Functions::GridFunctionInterface<E>& diffusion_factor,
-           XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
-           V& dg_vec) {
-          return compute_flux_reconstruction(grid, dg_space, rtn_space, diffusion_factor, diffusion_tensor, dg_vec);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "dg_space"_a,
-        "rtn_space"_a,
-        "diffusion_factor"_a,
-        "diffusion_tensor"_a,
-        "dg_DoF_vector"_a);
+  m.def(
+      "compute_flux_reconstruction",
+      [](GP& grid, DG& dg_space, RTN& rtn_space, XT::Functions::FunctionInterface<d>& diffusion_factor, V& dg_vec) {
+        const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
+            XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
+        return compute_flux_reconstruction(grid,
+                                           dg_space,
+                                           rtn_space,
+                                           diffusion_factor.as_grid_function<E>(),
+                                           diffusion_tensor.as_grid_function<E>(),
+                                           dg_vec);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "dg_space"_a,
+      "rtn_space"_a,
+      "diffusion_factor"_a,
+      "dg_DoF_vector"_a);
+  m.def(
+      "compute_flux_reconstruction",
+      [](GP& grid,
+         DG& dg_space,
+         RTN& rtn_space,
+         XT::Functions::GridFunctionInterface<E>& diffusion_factor,
+         XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
+         V& dg_vec) {
+        return compute_flux_reconstruction(grid, dg_space, rtn_space, diffusion_factor, diffusion_tensor, dg_vec);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "dg_space"_a,
+      "rtn_space"_a,
+      "diffusion_factor"_a,
+      "diffusion_tensor"_a,
+      "dg_DoF_vector"_a);
 
-  m.def("assemble_Hdiv_product_matrix",
-        [](RTN& rtn_space, const bool parallel) {
-          auto op = make_matrix_operator<M>(rtn_space, Stencil::element_and_intersection);
-          op.append(LocalElementIntegralBilinearForm<E, d>(LocalElementProductIntegrand<E, d>()));
-          op.append(LocalElementIntegralBilinearForm<E, d>(
-              [](const auto& test_basis, const auto& ansatz_basis, const auto& /*param*/) {
-                return std::max(test_basis.order() - 1, 0) + std::max(ansatz_basis.order() - 1, 0);
-              },
-              [](const auto& test_basis,
-                 const auto& ansatz_basis,
-                 const auto& point_in_reference_element,
-                 auto& result,
-                 const auto& /*param*/) {
-                auto test_grads = test_basis.jacobians_of_set(point_in_reference_element);
-                auto ansatz_grads = ansatz_basis.jacobians_of_set(point_in_reference_element);
-                auto divergence = [](const auto& grad) {
-                  double div = 0.;
+  m.def(
+      "assemble_Hdiv_product_matrix",
+      [](RTN& rtn_space, const bool parallel) {
+        auto op = make_matrix_operator<M>(rtn_space, Stencil::element_and_intersection);
+        op.append(LocalElementIntegralBilinearForm<E, d>(LocalElementProductIntegrand<E, d>()));
+        op.append(LocalElementIntegralBilinearForm<E, d>(
+            [](const auto& test_basis, const auto& ansatz_basis, const auto& /*param*/) {
+              return std::max(test_basis.order() - 1, 0) + std::max(ansatz_basis.order() - 1, 0);
+            },
+            [](const auto& test_basis,
+               const auto& ansatz_basis,
+               const auto& point_in_reference_element,
+               auto& result,
+               const auto& /*param*/) {
+              auto test_grads = test_basis.jacobians_of_set(point_in_reference_element);
+              auto ansatz_grads = ansatz_basis.jacobians_of_set(point_in_reference_element);
+              auto divergence = [](const auto& grad) {
+                double div = 0.;
+                for (size_t dd = 0; dd < d; ++dd)
+                  div += grad[dd][dd];
+                return div;
+              };
+              for (size_t ii = 0; ii < test_basis.size(); ++ii)
+                for (size_t jj = 0; jj < ansatz_basis.size(); ++jj)
                   for (size_t dd = 0; dd < d; ++dd)
-                    div += grad[dd][dd];
-                  return div;
-                };
-                for (size_t ii = 0; ii < test_basis.size(); ++ii)
-                  for (size_t jj = 0; jj < ansatz_basis.size(); ++jj)
-                    for (size_t dd = 0; dd < d; ++dd)
-                      result[ii][jj] = divergence(test_grads[ii]) * divergence(ansatz_grads[jj]);
-              }));
-          op.assemble(parallel);
-          return std::make_unique<M>(std::move(op.matrix()));
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "dg_space"_a,
-        "parallel"_a = true);
+                    result[ii][jj] = divergence(test_grads[ii]) * divergence(ansatz_grads[jj]);
+            }));
+        op.assemble(parallel);
+        return std::make_unique<M>(std::move(op.matrix()));
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "dg_space"_a,
+      "parallel"_a = true);
 
-  m.def("compute_local_conservation_error",
-        [](GP& grid, VectorDF& flux, XT::Functions::FunctionInterface<d>& rhs, const bool parallel) {
-          return compute_local_conservation_error(grid, flux, rhs.as_grid_function<E>(), parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "flux"_a,
-        "rhs"_a,
-        "parallel"_a = true);
-  m.def("compute_local_conservation_error",
-        [](GP& grid, VectorDF& flux, XT::Functions::GridFunctionInterface<E>& rhs, const bool parallel) {
-          return compute_local_conservation_error(grid, flux, rhs, parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "flux"_a,
-        "rhs"_a,
-        "parallel"_a = true);
+  m.def(
+      "compute_local_conservation_error",
+      [](GP& grid, VectorDF& flux, XT::Functions::FunctionInterface<d>& rhs, const bool parallel) {
+        return compute_local_conservation_error(grid, flux, rhs.as_grid_function<E>(), parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "flux"_a,
+      "rhs"_a,
+      "parallel"_a = true);
+  m.def(
+      "compute_local_conservation_error",
+      [](GP& grid, VectorDF& flux, XT::Functions::GridFunctionInterface<E>& rhs, const bool parallel) {
+        return compute_local_conservation_error(grid, flux, rhs, parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "flux"_a,
+      "rhs"_a,
+      "parallel"_a = true);
 
-  m.def("compute_estimate",
-        [](GP& grid,
-           ScalarDF& pressure,
-           VectorDF& flux,
-           XT::Functions::FunctionInterface<d>& rhs,
-           XT::Functions::FunctionInterface<d>& diffusion_factor,
-           XT::Functions::FunctionInterface<d>& diffusion_factor_bar,
-           XT::Functions::FunctionInterface<d>& diffusion_factor_hat,
-           const double& alpha_bar,
-           const double& alpha_hat,
-           const double& gamma_bar,
-           const int over_integrate,
-           const bool& parallel) {
-          const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
-              XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
-          return compute_estimate(grid,
-                                  pressure,
-                                  flux,
-                                  rhs.as_grid_function<E>(),
-                                  diffusion_factor.as_grid_function<E>(),
-                                  diffusion_factor_bar.as_grid_function<E>(),
-                                  diffusion_factor_hat.as_grid_function<E>(),
-                                  diffusion_tensor.as_grid_function<E>(),
-                                  alpha_bar,
-                                  alpha_hat,
-                                  gamma_bar,
-                                  over_integrate,
-                                  parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "pressure"_a,
-        "flux"_a,
-        "rhs"_a,
-        "diffusion_factor"_a,
-        "diffusion_factor_bar"_a,
-        "diffusion_factor_hat"_a,
-        "alpha_bar"_a,
-        "alpha_hat"_a,
-        "gamma_bar"_a,
-        "over_integrate"_a = 3,
-        "parallel"_a = true);
-  m.def("compute_estimate",
-        [](GP& grid,
-           ScalarDF& pressure,
-           VectorDF& flux,
-           XT::Functions::GridFunctionInterface<E>& rhs,
-           XT::Functions::GridFunctionInterface<E>& diffusion_factor,
-           XT::Functions::GridFunctionInterface<E>& diffusion_factor_bar,
-           XT::Functions::GridFunctionInterface<E>& diffusion_factor_hat,
-           XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
-           const double& alpha_bar,
-           const double& alpha_hat,
-           const double& gamma_bar,
-           const int over_integrate,
-           const bool& parallel) {
-          return compute_estimate(grid,
-                                  pressure,
-                                  flux,
-                                  rhs,
-                                  diffusion_factor,
-                                  diffusion_factor_bar,
-                                  diffusion_factor_hat,
-                                  diffusion_tensor,
-                                  alpha_bar,
-                                  alpha_hat,
-                                  gamma_bar,
-                                  over_integrate,
-                                  parallel);
-        },
-        py::call_guard<py::gil_scoped_release>(),
-        "grid"_a,
-        "pressure"_a,
-        "flux"_a,
-        "rhs"_a,
-        "diffusion_factor"_a,
-        "diffusion_factor_bar"_a,
-        "diffusion_factor_hat"_a,
-        "diffusion_tensor"_a,
-        "alpha_bar"_a,
-        "alpha_hat"_a,
-        "gamma_bar"_a,
-        "over_integrate"_a = 3,
-        "parallel"_a = true);
+  m.def(
+      "compute_estimate",
+      [](GP& grid,
+         ScalarDF& pressure,
+         VectorDF& flux,
+         XT::Functions::FunctionInterface<d>& rhs,
+         XT::Functions::FunctionInterface<d>& diffusion_factor,
+         XT::Functions::FunctionInterface<d>& diffusion_factor_bar,
+         XT::Functions::FunctionInterface<d>& diffusion_factor_hat,
+         const double& alpha_bar,
+         const double& alpha_hat,
+         const double& gamma_bar,
+         const int over_integrate,
+         const bool& parallel) {
+        const XT::Functions::ConstantFunction<d, d, d> diffusion_tensor(
+            XT::Common::FieldMatrix<double, 2, d>({{1., 0.}, {0., 1.}}));
+        return compute_estimate(grid,
+                                pressure,
+                                flux,
+                                rhs.as_grid_function<E>(),
+                                diffusion_factor.as_grid_function<E>(),
+                                diffusion_factor_bar.as_grid_function<E>(),
+                                diffusion_factor_hat.as_grid_function<E>(),
+                                diffusion_tensor.as_grid_function<E>(),
+                                alpha_bar,
+                                alpha_hat,
+                                gamma_bar,
+                                over_integrate,
+                                parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "pressure"_a,
+      "flux"_a,
+      "rhs"_a,
+      "diffusion_factor"_a,
+      "diffusion_factor_bar"_a,
+      "diffusion_factor_hat"_a,
+      "alpha_bar"_a,
+      "alpha_hat"_a,
+      "gamma_bar"_a,
+      "over_integrate"_a = 3,
+      "parallel"_a = true);
+  m.def(
+      "compute_estimate",
+      [](GP& grid,
+         ScalarDF& pressure,
+         VectorDF& flux,
+         XT::Functions::GridFunctionInterface<E>& rhs,
+         XT::Functions::GridFunctionInterface<E>& diffusion_factor,
+         XT::Functions::GridFunctionInterface<E>& diffusion_factor_bar,
+         XT::Functions::GridFunctionInterface<E>& diffusion_factor_hat,
+         XT::Functions::GridFunctionInterface<E, d, d>& diffusion_tensor,
+         const double& alpha_bar,
+         const double& alpha_hat,
+         const double& gamma_bar,
+         const int over_integrate,
+         const bool& parallel) {
+        return compute_estimate(grid,
+                                pressure,
+                                flux,
+                                rhs,
+                                diffusion_factor,
+                                diffusion_factor_bar,
+                                diffusion_factor_hat,
+                                diffusion_tensor,
+                                alpha_bar,
+                                alpha_hat,
+                                gamma_bar,
+                                over_integrate,
+                                parallel);
+      },
+      py::call_guard<py::gil_scoped_release>(),
+      "grid"_a,
+      "pressure"_a,
+      "flux"_a,
+      "rhs"_a,
+      "diffusion_factor"_a,
+      "diffusion_factor_bar"_a,
+      "diffusion_factor_hat"_a,
+      "diffusion_tensor"_a,
+      "alpha_bar"_a,
+      "alpha_hat"_a,
+      "gamma_bar"_a,
+      "over_integrate"_a = 3,
+      "parallel"_a = true);
 } // PYBIND11_MODULE(...)


### PR DESCRIPTION
Update to clang-format-8. Based on #185, so we should merge that PR first. Not too many changes here.